### PR TITLE
Fix handling of scalar arrays

### DIFF
--- a/src/Entity.php
+++ b/src/Entity.php
@@ -66,7 +66,11 @@ class Entity implements ArrayAccess
 
             if (is_array($value)) {
                 $newProps[$name] = array_map(function ($item) {
-                    return new Entity($item);
+                    if (is_object($item)) {
+                        return new Entity($item);
+                    }
+
+                    return $item;
                 }, $value);
                 continue;
             }

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -66,7 +66,7 @@ class Entity implements ArrayAccess
 
             if (is_array($value)) {
                 $newProps[$name] = array_map(function ($item) {
-                    if (is_object($item)) {
+                    if (is_object($item) || is_array($item)) {
                         return new Entity($item);
                     }
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -505,7 +505,7 @@ class ClientTest extends TestCase
         $this->assertEquals('id:in=1,2,3', urldecode($uri->getQuery()));
     }
 
-    protected function writeFunctionProvider()
+    public function writeFunctionProvider()
     {
         return [
             ['create'],

--- a/tests/EntityTest.php
+++ b/tests/EntityTest.php
@@ -64,6 +64,17 @@ class EntityTest extends TestCase
         $this->assertEquals('Jane', $this->entity->contacts[1]->name);
     }
 
+    /**
+     * @test
+     */
+    public function does_not_serialize_nested_scalar_values()
+    {
+        $this->loadSampleEntity();
+
+        $this->assertSame("Mr Jack Doe", $this->entity->aliases[0]);
+        $this->assertSame("Mr J Doe", $this->entity->aliases[1]);
+    }
+
     protected function loadSampleEntity()
     {
         $this->entity = new Entity([
@@ -82,6 +93,10 @@ class EntityTest extends TestCase
                     'name' => 'Jane',
                     'email' => 'jane@example.com',
                 ]
+            ],
+            'aliases' => [
+                'Mr Jack Doe',
+                'Mr J Doe'
             ]
         ]);
     }


### PR DESCRIPTION
This allows us to skip the conversion of arrays of strings, integers etc to an entity when it's not appropriate. 